### PR TITLE
Use an appropriate name for a constant in umalloc

### DIFF
--- a/umalloc.c
+++ b/umalloc.c
@@ -43,14 +43,16 @@ free(void *ap)
   freep = p;
 }
 
+#define NALLOC 1024	// min #units to request (to reduce calls to sbrk)
+
 static Header*
 morecore(uint nu)
 {
   char *p;
   Header *hp;
 
-  if(nu < 4096)
-    nu = 4096;
+  if(nu < NALLOC)
+    nu = NALLOC;
   p = sbrk(nu * sizeof(Header));
   if(p == (char*)-1)
     return 0;


### PR DESCRIPTION
Since the constant 4096 is typically the size of a page, use a
named constant in order to make clear that this is not the case
here.

This respect the original code from Kernighan and Ritchie,
(The C programming Language, 2nd ed. Section 8.7, page 188).