### PR TITLE
GDT base address alignment

### DIFF
--- a/bootasm.S
+++ b/bootasm.S
@@ -76,7 +76,7 @@ spin:
   jmp     spin
 
 # Bootstrap GDT
-.p2align 2                                # force 4 byte alignment
+.p2align 3                                # force 8 byte alignment
 gdt:
   SEG_NULLASM                             # null seg
   SEG_ASM(STA_X|STA_R, 0x0, 0xffffffff)   # code seg

--- a/entryother.S
+++ b/entryother.S
@@ -80,7 +80,7 @@ start32:
 spin:
   jmp     spin
 
-.p2align 2
+.p2align 3
 gdt:
   SEG_NULLASM
   SEG_ASM(STA_X|STA_R, 0, 0xffffffff)


### PR DESCRIPTION
According to Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volumn 3, Chapter 3, Section 3.5.1:

The base address of the GDT should be aligned on an eight-byte boundary to yield the best processor performance.