### PR TITLE
Aggiunge Dockerfile e script per avviare Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+#dependencies
+RUN apt update && apt install -y build-essential gcc-multilib libsdl1.2-dev libtool-bin libglib2.0-dev libz-dev libpixman-1-dev git cscope ctags wget
+
+# qemu
+RUN apt install -y qemu-system
+
+# gdb
+RUN apt install -y gdb
+
+ADD ./ /xv6-src
+WORKDIR /xv6-src
+
+RUN make
+

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Una volta clonato questo repository (`git clone https://github.com/zxgio/xv6-SET
 
 e, per mandarlo in esecuzione:
 - `make qemu-nox` lancia xv6; uscite con `poweroff` oppure con la sequenza `ctrl+A`, seguita da `x`
-- `make qmeu-nox-gdb` prepara xv6 per il debugging, per cui dovrete lanciare gdb da un altro terminale
+- `make qmeu-nox-gdb` prepara xdocker run --name xv6 --rm -it xv6 qemu-system-i386 -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp 1 -m 256 -nographicv6 per il debugging, per cui dovrete lanciare gdb da un altro terminale
   - se lanciando gdb ottenete: `warning: File "....xv6/.gdbinit" auto-loading has been declined ...`
     aggiungete la direttiva `add-auto-load-safe-path` al vostro `~/.gdbinit` (come suggerito da gdb stesso)
 
@@ -65,3 +65,16 @@ Durante l'esecuzione `ctrl+P`, catturato dalla console di xv6, mostra la lista d
 Invece, `ctrl+A`, seguito da `c`, (dis)attiva la console di QEMU. Dalla console potete uscire dall'emulazione con `q` o, per esempio, vedere la tabella delle pagine con `info mem`.
 
 Se ricompilate QEMU vi conviene impostare la variabile d'ambiente XV6_SETI_QEMU_HOME (vedi Makefile)
+
+## Docker
+
+Ho aggiunto una versione "Dockerizzata" per assicurare che giri su tutti i sistemi operativi.
+
+L'uso, dopo aver installato Docker, è molto semplice, basta avviare lo script start_docker.sh con il comando:  
+`./start_docker.sh`  
+
+Questo script crea l'immagine e la avvia correttamente ogni volta.
+
+Se si vuole evitare di fare il Docker build ad ogni avvio, dopo avere fatto il primo con successo si puo' usare il comando:  
+`docker run --name xv6 --rm -it xv6 qemu-system-i386 -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp 1 -m 256 -nographic`
+

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Alcune cose sono state modificate, in particolare:
 
 ## Software necessario/suggerito (istruzioni per Ubuntu 18.04)
 
-Installate i pacchetti: `build-essential gcc-multilib libsdl1.2-dev libtool-bin libglib2.0-dev libz-dev libp
-ixman-1-dev git cscope ctags wget`
+Installate i pacchetti: `build-essential gcc-multilib libsdl1.2-dev libtool-bin libglib2.0-dev libz-dev libpixman-1-dev git cscope ctags wget`
 
 ### gdb
 

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,3 @@
+docker build -t xv6 .
+docker run --name xv6 --rm -it xv6 qemu-system-i386 -drive file=fs.img,index=1,media=disk,format=raw -drive file=xv6.img,index=0,media=disk,format=raw -smp 1 -m 256 -nographic
+


### PR DESCRIPTION
Ho provato a compilare ed avviare Xv6 da entrambi Manjaro e MX Linux.  
Dal primo, Arch based, per qualche ragione non si avvia, o meglio, sembra avviarsi ma continua a flickerare.  
Dal secondo invece, Debian based, funziona alla perfezione.  
Siccome sul mio portatile che porto a lezione ho pero' Manjaro, ho creato un Docker basato su ubuntu che compila e prepara all'avvio Xv6 assieme allo script che lo avvia (e ne fa la build).  