### PR TITLE
implemented fix for potential deadlock between create,link and unlink

### DIFF
--- a/sysfile.c
+++ b/sysfile.c
@@ -222,7 +222,9 @@ sys_unlink(void)
     dp->nlink--;
     iupdate(dp);
   }
+  iunlock(ip);
   iunlockput(dp);
+  ilock(ip);
 
   ip->nlink--;
   iupdate(ip);
@@ -277,7 +279,9 @@ create(char *path, short type, short major, short minor)
   if(dirlink(dp, name, ip->inum) < 0)
     panic("create: dirlink");
 
+  iunlock(ip);
   iunlockput(dp);
+  ilock(ip);
 
   return ip;
 }


### PR DESCRIPTION
the call to iunlockput(dp) in create and sys_unlink is done while being locked on ip.
both method and sys_link, if performed on the same directory and file, attempt to lock both locks.
if during iunlockput, in the time the lock is released between iunlock and iput, the lock is acquired by another method, a deadlock will occur when said method attempt to acquire ip.
example-
1.process 1 calls lock(dp) in create
2.process 2 calles sys_link and reaches line 146 - ilock(dp) and attempts to acquire the lock, waiting because process 1 is locked on it.
3. process 1 calls lock(ip) and then reaches iunlockput(dp) and releases dp in iunlock.
4.process 2 acquires dp in line 146 and calls dirlink in the if right after, inside dirlink the first if is resolved to true, the same ip from process 1 returns, and process 2 attempts to acquire ip, which was already acquired by process 1, and goes to sleep.
5.process 1 continues to iput(dp) inside iunlockput and attempts to acquire dp, which is locked by process 2.
both processes are waiting for each other - deadlock.